### PR TITLE
Multi-objective Fixes

### DIFF
--- a/plugins/expression-basic/src/main/java/epmc/expression/standard/evaluatorexplicit/EvaluatorExplicitOperatorShortcutImplies.java
+++ b/plugins/expression-basic/src/main/java/epmc/expression/standard/evaluatorexplicit/EvaluatorExplicitOperatorShortcutImplies.java
@@ -123,6 +123,7 @@ public final class EvaluatorExplicitOperatorShortcutImplies implements Evaluator
         assert builder.getExpression() != null;
         assert builder.getVariables() != null;
         this.expression = (ExpressionOperator) builder.getExpression();
+        this.variables = builder.getVariables();
         operands = new EvaluatorExplicitBoolean[expression.getOperands().size()];
         operandValues = new Value[expression.getOperands().size()];
         Type[] types = new Type[expression.getOperands().size()];

--- a/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/ProblemsMultiObjective.java
+++ b/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/ProblemsMultiObjective.java
@@ -27,6 +27,7 @@ public final class ProblemsMultiObjective {
     public final static String ERROR_MULTI_OBJECTIVE = "ErrorMultiObjective";
     public final static Problem MULTI_OBJECTIVE_UNEXPECTED_INFEASIBLE = newProblem("multi-objective-unexpected-infeasible");
     public final static Problem MULTI_OBJECTIVE_INITIAL_NOT_SINGLETON = newProblem("multi-objective-initial-not-singleton");
+    public final static Problem MULTI_OBJECTIVE_UNSUPPORTED_OBJECTIVE = newProblem("multi-objective-unsupported-objective");
 
     private static Problem newProblem(String name) {
         assert name != null;

--- a/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/ProductBuilder.java
+++ b/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/ProductBuilder.java
@@ -81,6 +81,7 @@ final class ProductBuilder {
     private ExpressionMultiObjective property;
     private GraphExplicit graph;
     private BitSet invertedRewards;
+    private BitSet rewardProperties;
 
     ProductBuilder() {
     }
@@ -102,6 +103,11 @@ final class ProductBuilder {
 
     ProductBuilder setInvertedRewards(BitSet invertedRewards) {
         this.invertedRewards = invertedRewards;
+        return this;
+    }
+
+    ProductBuilder setRewardProperties(BitSet rewardProperties) {
+        this.rewardProperties = rewardProperties;
         return this;
     }
 
@@ -278,6 +284,7 @@ final class ProductBuilder {
         for (int prop = 0; prop < numAutomata; prop++) {
             initBitSet.set(prop);
         }
+        initBitSet.andNot(rewardProperties);
         todo.add(initBitSet);
         GraphExplicit prodWrapper = builder.getInputGraph();
         BitSet todoBS = UtilBitSet.newBitSetUnbounded();

--- a/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/PropertySolverExplicitMultiObjective.java
+++ b/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/PropertySolverExplicitMultiObjective.java
@@ -187,6 +187,7 @@ public final class PropertySolverExplicitMultiObjective implements PropertySolve
         property = propertyMultiObjective = normaliser.getNormalisedProperty();
         Expression subtractNumericalFrom = normaliser.getSubtractNumericalFrom();
         BitSet invertedRewards = normaliser.getInvertedRewards();
+        BitSet rewardProperties = normaliser.getRewardProperties();
         getLog().send(MessagesMultiObjective.DONE_NORMALISING_FORMULA);
         getLog().send(MessagesMultiObjective.STARTING_NESTED_FORMULAS);
         prepareRequiredPropositionals();
@@ -198,6 +199,7 @@ public final class PropertySolverExplicitMultiObjective implements PropertySolve
                 .setModelChecker(modelChecker)
                 .setGraph(graph)
                 .setInvertedRewards(invertedRewards)
+                .setRewardProperties(rewardProperties)
                 .build();
         getLog().send(MessagesMultiObjective.DONE_PRODUCT);
         StateMap result = mainLoop(product, subtractNumericalFrom);

--- a/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/PropertySolverExplicitMultiObjective.java
+++ b/plugins/propertysolver-multiobjective/src/main/java/epmc/multiobjective/PropertySolverExplicitMultiObjective.java
@@ -369,7 +369,7 @@ public final class PropertySolverExplicitMultiObjective implements PropertySolve
         boolean numerical = MultiObjectiveUtils.isNumericalQuery(propertyMultiObjective);
         ValueArray resultValues;
         if (numerical) {
-            //            ensure(feasible, ProblemsMultiObjective.MULTI_OBJECTIVE_UNEXPECTED_INFEASIBLE);
+            ensure(feasible, ProblemsMultiObjective.MULTI_OBJECTIVE_UNEXPECTED_INFEASIBLE);
             resultValues = newValueArrayWeight(forStates.size());
             ValueAlgebra entry = newValueWeight();
             bounds.get(entry, 0);

--- a/plugins/propertysolver-multiobjective/src/main/resources/ErrorMultiObjective.properties
+++ b/plugins/propertysolver-multiobjective/src/main/resources/ErrorMultiObjective.properties
@@ -1,2 +1,3 @@
 multi-objective-unexpected-infeasible = Numerical multi-objective problem is infeasible
 multi-objective-initial-not-singleton = There must be only one initial state for multi-objective analysis
+multi-objective-unsupported-objective = Unsupported objective found in multi-objective problem


### PR DESCRIPTION
This resolves several problems in the multi-objective model checking engine. 

First of all, it removes a NullPointerException that was thrown for several properties since the variables instance variable was never set in EvaluatorExplicitOperatorShortcutImplies.
Also, infeasible multi-objective properties are reported again.
Lastly, stop-rewards were handed-out for rewards, even though they should only be handed out for probabilistic subproperties. For example, this caused the property _multi(R{"time"}min=? [C], R{"energy"}<=43.99999993400001 [C])_ on
https://github.com/tquatmann/qcomp23-multi/blob/v1.0/models/rov/rov.prism with constants _B=10,Unf=2_ and an absolute _--graphsolver-iterative-stop-criterion_ to report a result of _-1_, even though there are no negative rewards in the model.